### PR TITLE
Add robots.txt, sitemap.xml, Link headers (#90)

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,135 @@
+# dox402 — pay-per-use AI inference on Cloudflare Workers
+# https://github.com/iglesiasbrandon/dox402
+#
+# General policy:
+#   - The marketing/docs homepage and machine-readable specs are public.
+#   - Authenticated and admin API endpoints are off-limits to all crawlers
+#     (they require a SIWE session or admin bearer token anyway).
+
+User-agent: *
+Allow: /
+Allow: /openapi.json
+Allow: /SKILL.md
+Allow: /.well-known/agent.json
+Allow: /.well-known/agents.json
+Allow: /sitemap.xml
+Allow: /robots.txt
+Allow: /health
+Allow: /payment-info
+Disallow: /infer
+Disallow: /balance
+Disallow: /history
+Disallow: /documents
+Disallow: /auth/
+Disallow: /admin/
+
+# ── AI / LLM crawler rules ─────────────────────────────────────────────────
+# Permissive on the public docs and machine-readable specs so the project is
+# discoverable by agents and search-grounding bots; off-limits on API endpoints
+# (which gate on payment + signed session anyway).
+
+User-agent: GPTBot
+Allow: /
+Allow: /openapi.json
+Allow: /SKILL.md
+Allow: /.well-known/agent.json
+Allow: /.well-known/agents.json
+Allow: /sitemap.xml
+Disallow: /infer
+Disallow: /balance
+Disallow: /history
+Disallow: /documents
+Disallow: /auth/
+Disallow: /admin/
+
+User-agent: OAI-SearchBot
+Allow: /
+Allow: /openapi.json
+Allow: /SKILL.md
+Allow: /.well-known/agent.json
+Allow: /.well-known/agents.json
+Allow: /sitemap.xml
+Disallow: /infer
+Disallow: /balance
+Disallow: /history
+Disallow: /documents
+Disallow: /auth/
+Disallow: /admin/
+
+User-agent: Claude-Web
+Allow: /
+Allow: /openapi.json
+Allow: /SKILL.md
+Allow: /.well-known/agent.json
+Allow: /.well-known/agents.json
+Allow: /sitemap.xml
+Disallow: /infer
+Disallow: /balance
+Disallow: /history
+Disallow: /documents
+Disallow: /auth/
+Disallow: /admin/
+
+User-agent: ClaudeBot
+Allow: /
+Allow: /openapi.json
+Allow: /SKILL.md
+Allow: /.well-known/agent.json
+Allow: /.well-known/agents.json
+Allow: /sitemap.xml
+Disallow: /infer
+Disallow: /balance
+Disallow: /history
+Disallow: /documents
+Disallow: /auth/
+Disallow: /admin/
+
+User-agent: Google-Extended
+Allow: /
+Allow: /openapi.json
+Allow: /SKILL.md
+Allow: /.well-known/agent.json
+Allow: /.well-known/agents.json
+Allow: /sitemap.xml
+Disallow: /infer
+Disallow: /balance
+Disallow: /history
+Disallow: /documents
+Disallow: /auth/
+Disallow: /admin/
+
+User-agent: PerplexityBot
+Allow: /
+Allow: /openapi.json
+Allow: /SKILL.md
+Allow: /.well-known/agent.json
+Allow: /.well-known/agents.json
+Allow: /sitemap.xml
+Disallow: /infer
+Disallow: /balance
+Disallow: /history
+Disallow: /documents
+Disallow: /auth/
+Disallow: /admin/
+
+User-agent: CCBot
+Allow: /
+Allow: /openapi.json
+Allow: /SKILL.md
+Allow: /.well-known/agent.json
+Allow: /.well-known/agents.json
+Allow: /sitemap.xml
+Disallow: /infer
+Disallow: /balance
+Disallow: /history
+Disallow: /documents
+Disallow: /auth/
+Disallow: /admin/
+
+# Content signals (cloudflare.com/ai-bots/ proposal):
+#   ai-train=no   — do not use this content to train models
+#   search=yes    — OK to surface in search results
+#   ai-input=yes  — OK to use as grounding input for live AI answers
+Content-Signal: ai-train=no, search=yes, ai-input=yes
+
+Sitemap: https://dox402.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://dox402.com/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://dox402.com/openapi.json</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://dox402.com/SKILL.md</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://dox402.com/.well-known/agent.json</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://dox402.com/.well-known/agents.json</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+</urlset>

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,7 +170,43 @@ export default {
   },
 };
 
+// RFC 8288 Link headers advertising machine-readable specs alongside the HTML homepage.
+// Crawlers and agents can discover OpenAPI / agent cards / SKILL.md without parsing HTML.
+const HOMEPAGE_LINK_HEADER = [
+  '</openapi.json>; rel="service-desc"; type="application/json"',
+  '</.well-known/agent.json>; rel="describedby"; type="application/json"',
+  '</.well-known/agents.json>; rel="describedby"; type="application/json"',
+  '</SKILL.md>; rel="service-doc"; type="text/markdown"',
+].join(', ');
+
 async function handleRequest(request: Request, env: Env, url: URL): Promise<Response> {
+    // ── Homepage with Link headers ───────────────────────────────────────
+    // Intercept GET / when the client wants HTML so we can attach RFC 8288
+    // Link headers pointing at machine-readable specs. All other asset paths
+    // (openapi.json, robots.txt, sitemap.xml, etc.) fall through to Cloudflare
+    // Workers Assets via the platform's normal asset-first routing.
+    if (
+      (url.pathname === '/' || url.pathname === '/index.html') &&
+      request.method === 'GET' &&
+      (request.headers.get('Accept')?.includes('text/html') ?? false) &&
+      env.ASSETS
+    ) {
+      const assetResponse = await env.ASSETS.fetch(request);
+      const contentType = assetResponse.headers.get('Content-Type') ?? '';
+      // Only attach Link headers to HTML responses — never to redirects,
+      // 404 fallbacks, or anything the assets layer chose to serve as non-HTML.
+      if (assetResponse.ok && contentType.toLowerCase().includes('text/html')) {
+        const headers = new Headers(assetResponse.headers);
+        headers.set('Link', HOMEPAGE_LINK_HEADER);
+        return new Response(assetResponse.body, {
+          status: assetResponse.status,
+          statusText: assetResponse.statusText,
+          headers,
+        });
+      }
+      return assetResponse;
+    }
+
     // ── Public endpoints ─────────────────────────────────────────────────
 
     // GET /health — liveness probe

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,4 +165,5 @@ export interface Env {
   ADMIN_SECRET?: string;        // admin Bearer token (set via wrangler secret put)
   ANALYTICS?: AnalyticsEngineDataset; // Cloudflare Analytics Engine — fire-and-forget event tracking
   RAG_STORAGE: R2Bucket;              // R2 bucket for RAG document content storage
+  ASSETS: Fetcher;                    // Cloudflare Workers Assets binding — serves files in ./public
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -9,6 +9,7 @@ invocation_logs = true
 
 [assets]
 directory = "./public"
+binding = "ASSETS"
 
 [ai]
 binding = "AI"


### PR DESCRIPTION
## Summary

Three discoverability fixes so AI agents and search crawlers can find dox402's public docs and machine-readable specs without poking at the authenticated API surface. Closes part of #90.

### 1. `public/robots.txt`
- General `User-agent: *` rules: allow homepage + public specs (`/openapi.json`, `/SKILL.md`, `/.well-known/agent.json`, `/.well-known/agents.json`, `/health`, `/payment-info`, `/sitemap.xml`); disallow authenticated/admin endpoints (`/infer`, `/balance`, `/history`, `/documents`, `/auth/`, `/admin/`).
- Explicit per-bot policies for `GPTBot`, `OAI-SearchBot`, `Claude-Web`, `ClaudeBot`, `Google-Extended`, `PerplexityBot`, `CCBot` (mirror of the general rules).
- `Content-Signal: ai-train=no, search=yes, ai-input=yes` — reasonable for a public-facing API: docs can be searched and grounded on, but not used to train models.
- `Sitemap: https://dox402.com/sitemap.xml`.

### 2. `public/sitemap.xml`
- Standard sitemaps.org 0.9 format.
- Lists canonical public URLs: homepage, OpenAPI, SKILL.md, both well-known agent files.
- Right now the homepage is a single-page document with anchor sections rather than separate URLs, so only `/` is listed for it.

### 3. RFC 8288 `Link` headers on `/`
- New route in `src/index.ts` matches `GET /` (and `/index.html`) when `Accept` includes `text/html`, proxies to `env.ASSETS.fetch(request)`, and attaches:
  - `</openapi.json>; rel="service-desc"; type="application/json"`
  - `</.well-known/agent.json>; rel="describedby"; type="application/json"`
  - `</.well-known/agents.json>; rel="describedby"; type="application/json"`
  - `</SKILL.md>; rel="service-doc"; type="text/markdown"`
- Link header is **only** attached when the asset layer returns an HTML 2xx response — never on redirects, 404 fallbacks, or non-HTML payloads.
- Other paths (assets like `/openapi.json`, `/robots.txt`, `/sitemap.xml`) flow through Cloudflare Workers' normal asset-first routing untouched.
- CORS and security headers are unchanged — the homepage response is still wrapped by `withCors()` like every other route.

### Wiring changes
- `wrangler.toml`: added `binding = "ASSETS"` under `[assets]` so the Worker can call `env.ASSETS.fetch()`.
- `src/types.ts`: added `ASSETS: Fetcher` to the `Env` interface.

## Test plan
- [x] `npm test` — all 390 tests pass (no existing tests touched `/`, so this is purely additive).
- [ ] Smoke test in `wrangler dev`: `curl -i http://127.0.0.1:8787/` should include the `Link:` header on the HTML response, and `curl -i http://127.0.0.1:8787/openapi.json` should serve the asset normally with no `Link` header.
- [ ] Verify `curl http://127.0.0.1:8787/robots.txt` and `curl http://127.0.0.1:8787/sitemap.xml` after deploy.

Refs #90.