### PR TITLE
Add API Catalog (RFC 9727) and Agent Skills index (#90)

### DIFF
--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://agentskills.io/schemas/v0.2.0/index.json",
+  "skills": [
+    {
+      "name": "dox402",
+      "type": "skill",
+      "description": "A payment-gated AI inference API built on Cloudflare Workers and Durable Objects. No signup, no API key -- authenticate with your Ethereum wallet, pay with USDC on Base Mainnet, and get AI responses. Each wallet gets isolated token balance, conversation history, and rate limiting via per-wallet Durable Objects with embedded SQLite storage.",
+      "url": "https://dox402.com/SKILL.md",
+      "sha256": "51c2b1ab2be2b3f90e14f18dd08cf4c5fc76013577c9923a0a4b4fb5e6ce8b44"
+    }
+  ]
+}

--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -1,0 +1,25 @@
+{
+  "linkset": [
+    {
+      "anchor": "https://dox402.com/",
+      "service-desc": [
+        {
+          "href": "https://dox402.com/openapi.json",
+          "type": "application/json"
+        }
+      ],
+      "service-doc": [
+        {
+          "href": "https://dox402.com/SKILL.md",
+          "type": "text/markdown"
+        }
+      ],
+      "status": [
+        {
+          "href": "https://dox402.com/health",
+          "type": "application/json"
+        }
+      ]
+    }
+  ]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -249,6 +249,20 @@ async function handleRequest(request: Request, env: Env, url: URL): Promise<Resp
       });
     }
 
+    // GET /.well-known/api-catalog — RFC 9727 API Catalog (linkset+json).
+    // Workers Static Assets serves extensionless files as application/octet-stream;
+    // re-serve here with the correct media type so RFC 9727 consumers see it.
+    if (url.pathname === '/.well-known/api-catalog' && request.method === 'GET') {
+      const assetRes = await env.ASSETS.fetch(request);
+      if (!assetRes.ok) {
+        return new Response('Not found', { status: 404 });
+      }
+      const body = await assetRes.arrayBuffer();
+      const headers = new Headers(assetRes.headers);
+      headers.set('Content-Type', 'application/linkset+json');
+      return new Response(body, { status: assetRes.status, headers });
+    }
+
     // GET /payment-info — payment address + network details for client top-up UI
     if (url.pathname === '/payment-info' && request.method === 'GET') {
       return Response.json({

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -356,6 +356,39 @@ describe('Security headers', () => {
   });
 });
 
+// ── /.well-known/api-catalog (RFC 9727) ─────────────────────────────────────
+
+describe('GET /.well-known/api-catalog', () => {
+  function makeAssetsFetcher(body: string, status = 200) {
+    return {
+      fetch: vi.fn(async () => new Response(body, {
+        status,
+        // Cloudflare Static Assets serves extensionless files as octet-stream;
+        // mimic that here so we know the route is overriding it.
+        headers: { 'Content-Type': 'application/octet-stream' },
+      })),
+    } as unknown as Fetcher;
+  }
+
+  it('serves the asset with Content-Type: application/linkset+json', async () => {
+    const linkset = JSON.stringify({ linkset: [{ anchor: 'https://dox402.com/' }] });
+    const env = makeEnv({ ASSETS: makeAssetsFetcher(linkset) });
+    const req = new Request('https://dox402.example.com/.well-known/api-catalog', { method: 'GET' });
+    const res = await worker.fetch(req, env);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/linkset+json');
+    const text = await res.text();
+    expect(JSON.parse(text)).toEqual({ linkset: [{ anchor: 'https://dox402.com/' }] });
+  });
+
+  it('returns 404 when the asset layer does not have the file', async () => {
+    const env = makeEnv({ ASSETS: makeAssetsFetcher('Not found', 404) });
+    const req = new Request('https://dox402.example.com/.well-known/api-catalog', { method: 'GET' });
+    const res = await worker.fetch(req, env);
+    expect(res.status).toBe(404);
+  });
+});
+
 // ── SIWX Integration ──────────────────────────────────────────────────────────
 
 describe('SIWX on /infer', () => {


### PR DESCRIPTION
## Summary

Two more agent-discoverability artifacts on top of PR #91. Closes another slice of #90.

### 1. `public/.well-known/api-catalog` (RFC 9727)
- Single linkset entry anchored at `https://dox402.com/`.
- Links: `service-desc` -> `/openapi.json`, `service-doc` -> `/SKILL.md`, `status` -> `/health`.
- Workers Static Assets serves extensionless files as `application/octet-stream`, which is wrong for an RFC 9727 catalog. Added a small route in `src/index.ts` that intercepts `GET /.well-known/api-catalog`, reads the file via `env.ASSETS.fetch()`, and re-serves it with `Content-Type: application/linkset+json` (preserving status / other headers).

### 2. `public/.well-known/agent-skills/index.json` (Cloudflare Agent Skills Discovery v0.2.0)
- Single skill entry pointing at `/SKILL.md`.
- `sha256` field for integrity / drift detection: `51c2b1ab2be2b3f90e14f18dd08cf4c5fc76013577c9923a0a4b4fb5e6ce8b44` (computed via `shasum -a 256 public/SKILL.md`).
- `description` is the lead paragraph of `SKILL.md`.
- Served from a real `.json` extension so Workers Static Assets sets the right content-type automatically — no router work needed.

### Wiring

- `wrangler.toml`: added `binding = "ASSETS"` under `[assets]`.
- `src/types.ts`: added `ASSETS: Fetcher` to `Env`.

PR #91 introduces the same binding for its `Link` header route. If #91 lands first this should be a clean no-op rebase; if this lands first, #91 will see the binding already present. Trivial either way.

### Decisions

- Used `https://dox402.com/` (the canonical custom domain advertised in the existing `agent.json` / `SKILL.md`) as the anchor / link hrefs rather than the workers.dev URL, matching the rest of the public spec surface.
- Picked `/health` for `status` (over `/payment-info`) since RFC 9727 `status` is conventionally a liveness probe, and `/health` is the cheaper, dependency-free option.
- Did not pre-emptively add other skill URLs to `agent-skills/index.json` (e.g. agent.json) — v0.2.0 is for skill artifacts; the A2A agent card lives in its own well-known file.

## Test plan

- [x] `npm test` -> 392 passed (390 baseline + 2 new for the api-catalog route).
- [x] New tests cover (a) the `application/linkset+json` content-type override, (b) 404 fallback when the asset layer doesn't have the file.
- [ ] Smoke after deploy: `curl -i https://dox402.com/.well-known/api-catalog` shows `Content-Type: application/linkset+json` and a valid `linkset` body. `curl -i https://dox402.com/.well-known/agent-skills/index.json` shows `Content-Type: application/json`.

Refs #90.