### PR TITLE
Add Markdown for Agents content negotiation on / (#90)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -180,6 +180,39 @@ const HOMEPAGE_LINK_HEADER = [
 ].join(', ');
 
 async function handleRequest(request: Request, env: Env, url: URL): Promise<Response> {
+    // ── Markdown for Agents content negotiation ──────────────────────────
+    // When an agent asks for `Accept: text/markdown` on the homepage, serve
+    // SKILL.md instead of the HTML page. Implements Cloudflare's
+    // "Markdown for Agents" pattern so LLM crawlers get clean, token-efficient
+    // content without parsing HTML. HTML clients fall through to the next
+    // homepage interceptor (Link headers) and then to asset serving.
+    // Spec: https://developers.cloudflare.com/fundamentals/reference/markdown-for-agents/
+    if (
+      (url.pathname === '/' || url.pathname === '/index.html') &&
+      request.method === 'GET' &&
+      (request.headers.get('Accept')?.toLowerCase().includes('text/markdown') ?? false) &&
+      env.ASSETS
+    ) {
+      const skillResponse = await env.ASSETS.fetch(
+        new Request(new URL('/SKILL.md', request.url)),
+      );
+      if (skillResponse.ok) {
+        const markdown = await skillResponse.text();
+        // Approximate token count using the standard ~4 chars/token heuristic.
+        const approxTokens = Math.ceil(markdown.length / 4);
+        return new Response(markdown, {
+          status: 200,
+          headers: {
+            'Content-Type': 'text/markdown; charset=utf-8',
+            'Vary': 'Accept',
+            'x-markdown-tokens': String(approxTokens),
+            'Cache-Control': 'public, max-age=300',
+          },
+        });
+      }
+      // If SKILL.md is missing for some reason, fall through to HTML serving.
+    }
+
     // ── Homepage with Link headers ───────────────────────────────────────
     // Intercept GET / when the client wants HTML so we can attach RFC 8288
     // Link headers pointing at machine-readable specs. All other asset paths

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -137,6 +137,118 @@ function makeMockDONamespace(opts?: {
   };
 }
 
+// ── Markdown for Agents content negotiation ───────────────────────────────────
+
+describe('Markdown for Agents (Accept: text/markdown on /)', () => {
+  function makeMockAssets(skillBody: string, opts?: { ok?: boolean; status?: number }): Fetcher {
+    const ok = opts?.ok ?? true;
+    const status = opts?.status ?? 200;
+    return {
+      fetch: vi.fn(async (input: Request | string) => {
+        const u = typeof input === 'string' ? input : input.url;
+        if (u.endsWith('/SKILL.md')) {
+          return new Response(skillBody, {
+            status,
+            headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+          });
+        }
+        // Default: pretend HTML homepage
+        return new Response('<!doctype html><html><body>home</body></html>', {
+          status: 200,
+          headers: { 'Content-Type': 'text/html; charset=utf-8' },
+        });
+      }),
+    } as unknown as Fetcher;
+  }
+
+  const skillMd = '# dox402 — Pay-Per-Use AI Inference API\n\nBase URL: `https://example.com`\n';
+
+  it('GET / with Accept: text/markdown returns SKILL.md as markdown', async () => {
+    const env = makeEnv({ ASSETS: makeMockAssets(skillMd) });
+    const req = new Request('https://dox402.example.com/', {
+      method: 'GET',
+      headers: { 'Accept': 'text/markdown' },
+    });
+    const res = await worker.fetch(req, env);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('text/markdown; charset=utf-8');
+    expect(res.headers.get('Vary')).toBe('Accept');
+    const tokens = res.headers.get('x-markdown-tokens');
+    expect(tokens).toBeTruthy();
+    expect(Number(tokens)).toBeGreaterThan(0);
+    const body = await res.text();
+    expect(body).toContain('# dox402');
+    expect(body).toContain('Base URL');
+  });
+
+  it('GET /index.html with Accept: text/markdown also returns markdown', async () => {
+    const env = makeEnv({ ASSETS: makeMockAssets(skillMd) });
+    const req = new Request('https://dox402.example.com/index.html', {
+      method: 'GET',
+      headers: { 'Accept': 'text/markdown' },
+    });
+    const res = await worker.fetch(req, env);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('text/markdown; charset=utf-8');
+  });
+
+  it('GET / with Accept: text/markdown,text/html prefers markdown', async () => {
+    const env = makeEnv({ ASSETS: makeMockAssets(skillMd) });
+    const req = new Request('https://dox402.example.com/', {
+      method: 'GET',
+      headers: { 'Accept': 'text/markdown, text/html;q=0.9' },
+    });
+    const res = await worker.fetch(req, env);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('text/markdown; charset=utf-8');
+  });
+
+  it('GET / without Accept: text/markdown falls through (no markdown response)', async () => {
+    const assets = makeMockAssets(skillMd);
+    const env = makeEnv({ ASSETS: assets });
+    const req = new Request('https://dox402.example.com/', {
+      method: 'GET',
+      headers: { 'Accept': 'text/html' },
+    });
+    const res = await worker.fetch(req, env);
+    // Without ASSETS-based homepage interception in this branch, the router
+    // returns 404 for /. The key assertion is that we did NOT switch to markdown.
+    expect(res.headers.get('Content-Type')).not.toBe('text/markdown; charset=utf-8');
+    expect(res.headers.get('x-markdown-tokens')).toBeNull();
+  });
+
+  it('POST / with Accept: text/markdown does not trigger markdown path', async () => {
+    const env = makeEnv({ ASSETS: makeMockAssets(skillMd) });
+    const req = new Request('https://dox402.example.com/', {
+      method: 'POST',
+      headers: { 'Accept': 'text/markdown' },
+    });
+    const res = await worker.fetch(req, env);
+    expect(res.headers.get('Content-Type')).not.toBe('text/markdown; charset=utf-8');
+  });
+
+  it('markdown response includes CORS headers via withCors wrapper', async () => {
+    const env = makeEnv({ ASSETS: makeMockAssets(skillMd) });
+    const req = new Request('https://dox402.example.com/', {
+      method: 'GET',
+      headers: { 'Accept': 'text/markdown' },
+    });
+    const res = await worker.fetch(req, env);
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('https://dox402.example.com');
+    expect(res.headers.get('X-Content-Type-Options')).toBe('nosniff');
+  });
+
+  it('falls through when SKILL.md fetch fails (asset 404)', async () => {
+    const env = makeEnv({ ASSETS: makeMockAssets(skillMd, { ok: false, status: 404 }) });
+    const req = new Request('https://dox402.example.com/', {
+      method: 'GET',
+      headers: { 'Accept': 'text/markdown' },
+    });
+    const res = await worker.fetch(req, env);
+    expect(res.headers.get('Content-Type')).not.toBe('text/markdown; charset=utf-8');
+  });
+});
+
 // ── CORS ──────────────────────────────────────────────────────────────────────
 
 describe('CORS', () => {


### PR DESCRIPTION
Closes part of #90.

## Summary

Implements Cloudflare's [Markdown for Agents](https://developers.cloudflare.com/fundamentals/reference/markdown-for-agents/) pattern: when a client sends `Accept: text/markdown` to `GET /` (or `/index.html`), the worker serves `public/SKILL.md` as `text/markdown; charset=utf-8` instead of the HTML homepage.

LLM crawlers and agents get clean, token-efficient content without parsing HTML; browsers continue to receive the existing single-file frontend unchanged.

## Behavior

- `GET /` with `Accept: text/markdown` -> `200 text/markdown; charset=utf-8` body of `SKILL.md`
- `GET /index.html` with `Accept: text/markdown` -> same as above
- `GET /` with `Accept: text/html` (or no Accept) -> falls through to normal asset serving
- `POST /` with `Accept: text/markdown` -> not intercepted (only GET)
- If `SKILL.md` fetch fails for any reason, the request falls through to HTML serving

## Response headers

- `Content-Type: text/markdown; charset=utf-8`
- `Vary: Accept` so caches respect content negotiation
- `x-markdown-tokens: <approx>` using the standard chars/4 heuristic so agents can budget context
- `Cache-Control: public, max-age=300`
- CORS + security headers applied via the existing `withCors` wrapper

## Implementation notes

- Handler runs at the top of `handleRequest`, before any other route matching, so it cannot interfere with `/health`, `/infer`, etc.
- `ASSETS: Fetcher` is added to the `Env` interface and `binding = "ASSETS"` to `wrangler.toml`. PRs #91 and #92 add the same lines independently; git resolves cleanly when branches merge sequentially (whichever lands first wins, the others become no-ops on those lines).

## Test plan

- [x] `npm test` -- all 397 tests pass (45 in `index.test.ts`, including 7 new ones)
- [x] New tests cover: markdown response on `/`, `/index.html`, multi-value Accept header, fall-through when Accept is HTML, fall-through for POST, fall-through when SKILL.md is missing, and presence of CORS + security headers on the markdown response
- [ ] Manual smoke after deploy: `curl -H 'Accept: text/markdown' https://inference-gate.iglesias-brandon.workers.dev/ -i | head -20` should show `Content-Type: text/markdown` and the SKILL.md body