### PR TITLE
Document why Web Bot Auth and MCP Server Card don't apply (#90)

### DIFF
--- a/public/.well-known/README.md
+++ b/public/.well-known/README.md
@@ -1,0 +1,57 @@
+# `/.well-known/` for DOX402
+
+DOX402 is a destination REST API (Cloudflare Worker) that sells document
+inference for USDC on Base via x402, with auth via SIWE/SIWX/Bearer token.
+This directory holds the agent-discovery documents we publish, and this
+README records the deliberate decisions about ones we do not.
+
+## What we publish
+
+- **`agent.json`** — A2A agent card describing identity, transport, and
+  the high-level skill DOX402 offers.
+- **`agents.json`** — Multi-step agent flows (login, infer, balance, etc.)
+  pointing back at the OpenAPI spec.
+
+Related agent-readable documents live one directory up:
+
+- `/openapi.json` — OpenAPI 3.1 description of every REST endpoint.
+- `/SKILL.md` — Human/agent-readable usage guide.
+
+## What we deliberately do NOT publish
+
+### `/.well-known/http-message-signatures-directory`
+
+Per [draft-meunier-http-message-signatures-directory-00][bot-auth], this
+JWKS lists public keys a **bot** uses to sign its outgoing requests so
+destination servers can verify them. It is published by crawlers and other
+outbound-signing clients — not by destination services.
+
+DOX402 is the destination. It does not crawl other sites and does not sign
+outgoing requests. Publishing an empty or stub directory here would
+misrepresent us as a signing client.
+
+### `/.well-known/mcp/server-card.json`
+
+[SEP-1649][mcp-card] describes an MCP server's identity, transport, and
+capabilities. DOX402 does not expose an MCP server endpoint — it is a REST
+API documented via `openapi.json`. A future MCP wrapper around the REST
+surface is possible, but until that endpoint actually exists, publishing a
+server card would lie about a capability we do not have.
+
+### `/.well-known/openid-configuration` and `/.well-known/oauth-authorization-server`
+
+DOX402 authenticates via SIWE/SIWX wallet signatures (see `/auth/nonce` and
+`/auth/login`), not OAuth 2.0 / OIDC. Publishing OAuth/OIDC discovery
+metadata would advertise endpoints and flows we do not implement, and
+would mislead agents into attempting a handshake that cannot succeed.
+
+## Notes for future maintainers
+
+These decisions are tracked in [issue #90][issue-90]. If DOX402's
+architecture changes (e.g. an MCP endpoint is added, or the service starts
+making signed outbound requests), revisit the corresponding section above
+before adding the file — do not add it as a stub.
+
+[bot-auth]: https://www.ietf.org/archive/id/draft-meunier-http-message-signatures-directory-00.html
+[mcp-card]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127
+[issue-90]: https://github.com/iglesiasbrandon/dox402/issues/90


### PR DESCRIPTION
## Summary

Adds `public/.well-known/README.md` to record the deliberate decisions to NOT publish certain `/.well-known/` files that the [isitagentready.com scan](https://isitagentready.com/dox402.com) (issue #90) flags as missing. Both checks are technically accurate that the files don't exist — but for DOX402's architecture they fundamentally don't apply, and publishing stubs would actively mislead agents.

The README documents:

- **What we publish today:** `agent.json`, `agents.json` (and the related `/openapi.json` and `/SKILL.md` one directory up).
- **Why no `/.well-known/http-message-signatures-directory`:** Per [draft-meunier-http-message-signatures-directory-00](https://www.ietf.org/archive/id/draft-meunier-http-message-signatures-directory-00.html), this JWKS is published by **bots** (outbound-signing crawlers) so destination servers can verify their signatures. DOX402 is the destination — it never signs outgoing requests, so it has no public keys to advertise here.
- **Why no `/.well-known/mcp/server-card.json`:** Per [SEP-1649](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127), the card describes an MCP server's identity, transport, and capabilities. DOX402 doesn't expose an MCP server endpoint — it's a REST API. A future MCP wrapper is possible, but until that endpoint actually exists, publishing a card would advertise a capability we don't have.
- **Why no `/.well-known/openid-configuration` or `/.well-known/oauth-authorization-server`:** Auth is SIWE/SIWX wallet signing (`/auth/nonce`, `/auth/login`), not OAuth 2.0 / OIDC. OAuth metadata would advertise endpoints and flows that don't exist.

The README also tells future maintainers to revisit each section if the architecture changes (e.g. adding an MCP endpoint or making signed outbound requests) before adding the corresponding file — so these items don't get reopened against the codebase as it stands.

No code changes; documentation only.

Refs #90.

## Test plan

- [ ] Verify `public/.well-known/README.md` renders cleanly on GitHub.
- [ ] Confirm no other `/.well-known/` checks in #90 are inadvertently affected (this PR is documentation-only).