### PR TITLE
Add UCP/ACP discovery (or document why not) (#90)

### DIFF
--- a/public/.well-known/README.md
+++ b/public/.well-known/README.md
@@ -45,13 +45,62 @@ DOX402 authenticates via SIWE/SIWX wallet signatures (see `/auth/nonce` and
 metadata would advertise endpoints and flows we do not implement, and
 would mislead agents into attempting a handshake that cannot succeed.
 
+### `/.well-known/ucp`
+
+The [Universal Commerce Protocol][ucp] (UCP, Google + Shopify, announced
+January 2026) standardizes the **retail shopping lifecycle** for AI
+agents: product discovery, cart, checkout, order tracking, fulfillment,
+post-purchase support. A UCP manifest declares a merchant's catalog
+endpoints, checkout session URLs, payment handlers (Google Pay, PayPal,
+tokenized card PSPs), and webhook public keys — it is built around
+[`POST /ucp/checkout`][ucp-guide] and friends against a product inventory.
+
+DOX402 has no product catalog. It is a pay-per-call inference API priced
+in USDC at the HTTP layer via x402. There is no cart, no line items, no
+checkout session, no fulfillment lifecycle, and the payment rail is crypto
+rather than the card-PSP stack UCP handlers expect. Publishing a UCP
+manifest would require stub endpoints that do not exist; real UCP-aware
+agents (Google Shopping, Gemini surfaces) would then attempt a checkout
+handshake that cannot complete.
+
+The protocol comparisons agree x402 is the correct primitive for
+per-call API monetization and UCP is the wrong layer
+(["mostly useless if your agent is paying for APIs, data feeds, or other
+agent services"][protocols-compared]). The x402 payment details that UCP
+would otherwise cover are already advertised in `agent.json` under
+`x-payment` and programmatically at `/payment-info`.
+
+### `/.well-known/acp.json`
+
+The [Agentic Commerce Protocol][acp] (ACP, OpenAI + Stripe) is a
+**merchant checkout protocol** for in-chat purchases — the plumbing behind
+"Buy it in ChatGPT." It defines product feeds, a delegated-payment
+Shared Payment Token flow through Stripe (and other compatible PSPs), and
+a conversational checkout state machine. As of the 2026-04-17 spec, there
+is no standardized `/.well-known/acp.json` discovery document; the ACP
+maintainers note discovery mechanisms are still being designed.
+
+DOX402's model does not fit ACP either: no SKUs, no Shared Payment Token,
+no Stripe/PSP integration, and the transaction shape (streamed inference
+per HTTP request, settled in on-chain USDC) is not what ACP's checkout
+state machine describes. Even if a discovery format existed, the required
+fields would be inapplicable.
+
+If ACP later ships a discovery format that covers API-style services or
+crypto payment rails, revisit this decision.
+
 ## Notes for future maintainers
 
 These decisions are tracked in [issue #90][issue-90]. If DOX402's
-architecture changes (e.g. an MCP endpoint is added, or the service starts
-making signed outbound requests), revisit the corresponding section above
-before adding the file — do not add it as a stub.
+architecture changes (e.g. an MCP endpoint is added, the service starts
+making signed outbound requests, or a retail-style product surface is
+introduced), revisit the corresponding section above before adding the
+file — do not add it as a stub.
 
 [bot-auth]: https://www.ietf.org/archive/id/draft-meunier-http-message-signatures-directory-00.html
 [mcp-card]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127
+[ucp]: https://ucp.dev/
+[ucp-guide]: https://developers.google.com/merchant/ucp
+[acp]: https://github.com/agentic-commerce-protocol/agentic-commerce-protocol
+[protocols-compared]: https://atxp.ai/blog/agent-payment-protocols-compared/
 [issue-90]: https://github.com/iglesiasbrandon/dox402/issues/90


### PR DESCRIPTION
## Summary

Closes out the final two commerce-related items on #90 (UCP profile at `/.well-known/ucp`, ACP discovery at `/.well-known/acp.json`). After research, **neither spec applies to DOX402's model**, so this PR documents the decisions in `public/.well-known/README.md` rather than publishing stub files.

## What the specs are

- **UCP — [Universal Commerce Protocol](https://ucp.dev/)** (Google + Shopify, announced Jan 2026). Standardizes the retail shopping lifecycle for AI agents: product discovery, cart, checkout, order tracking, fulfillment. Manifest declares catalog endpoints, checkout session URLs, and payment handlers (Google Pay, PayPal, tokenized card PSPs). Built around `POST /ucp/checkout` against an inventory.
- **ACP — [Agentic Commerce Protocol](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol)** (OpenAI + Stripe). In-chat merchant checkout — the plumbing behind "Buy it in ChatGPT." Defines product feeds, a delegated Shared Payment Token through Stripe (and other PSPs), and a conversational checkout state machine. ACP maintainers explicitly state discovery mechanisms are still being designed — there is no standardized `/.well-known/acp.json` as of the 2026-04-17 spec.

## Decision: skip both, document why

DOX402 is a pay-per-call inference API priced in USDC at the HTTP layer via x402. It has no product catalog, no cart, no checkout session, no fulfillment lifecycle, and no Stripe/PSP integration. x402 is the correct layer for this model; third-party comparisons of the agent payment protocol stack reach the same conclusion (["mostly useless if your agent is paying for APIs, data feeds, or other agent services"](https://atxp.ai/blog/agent-payment-protocols-compared/)).

Publishing either file would require stub endpoints that do not exist, and real UCP- or ACP-aware agents (Google Shopping, Gemini, ChatGPT checkout) would then attempt a handshake that cannot complete — strictly worse than not being listed. The x402 details UCP would otherwise cover are already advertised in `agent.json` under `x-payment` and programmatically at `/payment-info`.

## Changes

- Extends `public/.well-known/README.md` (introduced in #94) with two new sections under "What we deliberately do NOT publish" covering the UCP and ACP decisions and the rationale.

## Merge order note

This branch was written assuming #94 is merged first. If this PR merges first, #94 will need a trivial conflict resolution (or this PR's content will already include #94's since the file contains both sets of sections).

Refs #90.

## Test plan

- [ ] Verify `public/.well-known/README.md` renders cleanly on GitHub.
- [ ] Confirm no code changes; this is documentation-only.